### PR TITLE
Add test_weakrefmethod.py to manifest.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include DESCRIPTION.rst
+include test_weakmethod.py


### PR DESCRIPTION
This file was being missed by the `setup.py sdist` command when building
source distributions, preventing the source package from being tested
and breaking tools like `stdeb`.
