### PR TITLE
Adding Python 3 support and fixed Python 2.6 bug.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,7 @@ setup(
     keywords='weakref WeakMethod',
     tests_require=['unittest2'],
     test_suite='test_weakmethod',
+    extra_requires={
+        'test': ["tox"]
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py26, py27, py32, py33
+
+[testenv]
+commands =
+    unit2
+deps =
+    unittest2

--- a/weakrefmethod/__init__.py
+++ b/weakrefmethod/__init__.py
@@ -1,2 +1,2 @@
-from _version import __version__
-from weakrefmethod import WeakMethod
+from ._version import __version__
+from .weakrefmethod import WeakMethod

--- a/weakrefmethod/weakrefmethod.py
+++ b/weakrefmethod/weakrefmethod.py
@@ -46,10 +46,6 @@ class WeakMethod(weakref.ref):
         return False
 
     def __ne__(self, other):
-        if isinstance(other, WeakMethod):
-            if not self._alive or not other._alive:
-                return self is not other
-            return weakref.ref.__ne__(self, other) or self._func_ref != other._func_ref
-        return True
+        return not self.__eq__(other)
 
     __hash__ = weakref.ref.__hash__


### PR DESCRIPTION
Hello,

I ran across some issues when using `weakrefmethod` on different versions of Python and took a shot at fixing them.

When running `unit2` on Python 2.6, I got the following error:

```
======================================================================
FAIL: test_equality (test_weakmethod.WeakMethodTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\dev\weakrefmethod\test_weakmethod.py", line 122, in test_equality
    _eq(a, b)
  File "C:\dev\weakrefmethod\test_weakmethod.py", line 111, in _eq
    self.assertFalse(a != b)
AssertionError: True is not false

----------------------------------------------------------------------
```

I think this is due to a `weakref.ref` behavior on Python 2.6. It seems the `__ne__` method returns a `NotImplementedType` object, which evaluates to `True` when used in a [boolean expression](https://github.com/twang817/weakrefmethod/blob/master/weakrefmethod/weakrefmethod.py#L52).

Example:

``` python
>>> import weakref
>>> def foo():
...     pass
...
>>>
>>> r1 = weakref.ref(foo)
>>> r2 = weakref.ref(foo)
>>>
>>> r1 == r2
True
>>>
>>> r1 != r2
False
>>>
>>> r1.__ne__(r2)
NotImplemented
>>>
>>> result = r1.__ne__(r2)
>>> bool(result)
True
```

On Python 3, the `weakrefmethod/__init__.py` imports fail because of the relative import syntax. I updated it to use explicit relative imports which works on Python 2.6+. After altering the imports and running the tests, `weakrefmethod` appears to work on Python 3.2 and 3.3.

I also added the `tox.ini` file that I used for testing across different Python versions.

Thanks for considering this pull request and thank you for providing `weakrefmethod` to the Python community!
