### PR TITLE
Add automatic continuous check-in files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python: 2.7
+env:
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+  - TOX_ENV=py32
+  - TOX_ENV=py33
+install:
+  - pip install tox
+script:
+  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 install:
   - pip install unittest2
 script:
-  - python -m unittest2
+  - unit2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py32
-  - TOX_ENV=py33
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
 install:
-  - pip install tox
+  - pip install unittest2
 script:
-  - tox -e $TOX_ENV
+  - python -m unittest2

--- a/README.rst
+++ b/README.rst
@@ -4,3 +4,6 @@ weakrefmethod
 Backport of WeakMethod from Python 3.4 to Python 2.6+
 
 `docs <https://docs.python.org/3/library/weakref.html#weakref.WeakMethod>`_
+
+.. image:: https://travis-ci.org/vrtsystems/weakrefmethod.svg?branch=master
+    :target: https://travis-ci.org/vrtsystems/weakrefmethod


### PR DESCRIPTION
This adds a `.travis.yml` file for continuous integration testing against Python 2.6, 2.7, 3.2 and 3.3.

Python 3.4 is skipped because one can simply use the built-in `weakref` support for methods, and supporting both is trivial.
