### PR TITLE
Fix 'unknown encoding' exception during install on OSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import io
 import os
 from setuptools import setup, find_packages
 
-version = io.open('weakrefmethod/_version.py').readlines()[-1].split()[-1].strip('"\'')
+version = io.open('weakrefmethod/_version.py',encoding='ascii').readlines()[-1].split()[-1].strip('"\'')
 
 setup(
     name='weakrefmethod',


### PR DESCRIPTION
Install out of pypi or the git master failing for me on OSX 10.9 / XCode 5.1.1
