### PR TITLE
support for setuptools>=66.1.0, which enforces no dash (-) in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [sdist]
-force-manifest = 1
+force_manifest = 1


### PR DESCRIPTION
after an update to setuptools version pip install fails for weakrefmethod and packages using it